### PR TITLE
Added SOVERSION field for shared library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,8 @@ set(SCN_EXPORT_TARGETS_LIST scn scn-header-only)
 add_library(scn::scn ALIAS scn)
 add_library(scn::scn-header-only ALIAS scn-header-only)
 
+set_property(TARGET scn PROPERTY SOVERSION 0)
+
 if (SCN_TESTS)
     enable_testing()
     add_subdirectory(test)


### PR DESCRIPTION
Most of GNU/Linux distributions require SOVERSION field of shared library to be set.

You should bump SOVERSION every time you draft a new release with breaking API changes.