### PR TITLE
check value of _HAS_EXCEPTIONS instead of only it's existence

### DIFF
--- a/include/scn/detail/config.h
+++ b/include/scn/detail/config.h
@@ -196,7 +196,11 @@
 #define SCN_HAS_EXCEPTIONS 1
 #endif
 #if !defined(SCN_HAS_EXCEPTIONS) && defined(_HAS_EXCEPTIONS)
+#if _HAS_EXCEPTIONS
 #define SCN_HAS_EXCEPTIONS 1
+#else
+#define SCN_HAS_EXCEPTIONS 0
+#endif
 #endif
 #if !defined(SCN_HAS_EXCEPTIONS) && !defined(_CPPUNWIND)
 #define SCN_HAS_EXCEPTIONS 0


### PR DESCRIPTION
It's a common practice to define `_HAS_EXCEPTIONS=0` to disable exceptions on windows. 
This can result in a false positive detection of whether exceptions are present.

Other libraries like `{fmt}` also check the value of `_HAS_EXCEPTIONS`.
https://github.com/fmtlib/fmt/blob/7e4ad40171aa552d38cb99a5c181a0d7b150facc/include/fmt/core.h#L146