### PR TITLE
MSVC: suppress warning 4146

### DIFF
--- a/src/reader_int.cpp
+++ b/src/reader_int.cpp
@@ -268,6 +268,7 @@ namespace scn {
             SCN_MSVC_IGNORE(4018)  // > signed/unsigned mismatch
             SCN_MSVC_IGNORE(4389)  // == signed/unsigned mismatch
             SCN_MSVC_IGNORE(4244)  // lossy conversion
+            SCN_MSVC_IGNORE(4146)  // result still unsigned
 
             using utype = typename std::make_unsigned<T>::type;
 


### PR DESCRIPTION
suppress this warning
warning C4146: unary minus operator applied to unsigned type, result still unsigned