### PR TITLE
Conditional locale support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ option(SCN_DISABLE_TYPE_CUSTOM "Disable scanning of user types" OFF)
 
 option(SCN_DISABLE_FROM_CHARS "Disallow falling back on std::from_chars when scanning floating-point values" OFF)
 option(SCN_DISABLE_STRTOD "Disallow falling back on std::strtod when scanning floating-point values" OFF)
+option(SCN_USE_STATIC_LOCALE "Disable all localization" OFF)
 
 file(READ include/scn/detail/config.h config_h)
 if (NOT config_h MATCHES "SCN_VERSION SCN_COMPILER\\(([0-9]+), ([0-9]+), ([0-9]+)\\)")
@@ -107,6 +108,9 @@ function(generate_library_target target_name)
     target_compile_features(${target_name} PUBLIC cxx_std_11)
     set_private_flags(${target_name})
 
+    target_compile_definitions(${target_name} PUBLIC
+        -DSCN_USE_STATIC_LOCALE=$<IF:$<BOOL:${SCN_USE_STATIC_LOCALE}>,1,0>)
+
     if (SCN_USE_BUNDLED_FAST_FLOAT)
         target_include_directories(${target_name} PRIVATE
                 $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/deps/fast_float/single_include>)
@@ -123,6 +127,9 @@ function(generate_header_only_target target_name)
     target_compile_definitions(${target_name} INTERFACE
             -DSCN_HEADER_ONLY=1)
     target_compile_features(${target_name} INTERFACE cxx_std_11)
+
+    target_compile_definitions(${target_name} INTERFACE
+        -DSCN_USE_STATIC_LOCALE=$<IF:$<BOOL:${SCN_USE_STATIC_LOCALE}>,1,0>)
 
     if (SCN_USE_BUNDLED_FAST_FLOAT)
         target_include_directories(${target_name} INTERFACE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ option(SCN_DISABLE_TYPE_CUSTOM "Disable scanning of user types" OFF)
 
 option(SCN_DISABLE_FROM_CHARS "Disallow falling back on std::from_chars when scanning floating-point values" OFF)
 option(SCN_DISABLE_STRTOD "Disallow falling back on std::strtod when scanning floating-point values" OFF)
-option(SCN_USE_STATIC_LOCALE "Disable all localization" OFF)
+option(SCN_DISABLE_LOCALE "Disable all localization" OFF)
 
 file(READ include/scn/detail/config.h config_h)
 if (NOT config_h MATCHES "SCN_VERSION SCN_COMPILER\\(([0-9]+), ([0-9]+), ([0-9]+)\\)")
@@ -108,9 +108,6 @@ function(generate_library_target target_name)
     target_compile_features(${target_name} PUBLIC cxx_std_11)
     set_private_flags(${target_name})
 
-    target_compile_definitions(${target_name} PUBLIC
-        -DSCN_USE_STATIC_LOCALE=$<IF:$<BOOL:${SCN_USE_STATIC_LOCALE}>,1,0>)
-
     if (SCN_USE_BUNDLED_FAST_FLOAT)
         target_include_directories(${target_name} PRIVATE
                 $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/deps/fast_float/single_include>)
@@ -127,9 +124,6 @@ function(generate_header_only_target target_name)
     target_compile_definitions(${target_name} INTERFACE
             -DSCN_HEADER_ONLY=1)
     target_compile_features(${target_name} INTERFACE cxx_std_11)
-
-    target_compile_definitions(${target_name} INTERFACE
-        -DSCN_USE_STATIC_LOCALE=$<IF:$<BOOL:${SCN_USE_STATIC_LOCALE}>,1,0>)
 
     if (SCN_USE_BUNDLED_FAST_FLOAT)
         target_include_directories(${target_name} INTERFACE

--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -23,6 +23,8 @@ function(get_config_flags flags)
 
             $<$<BOOL:${SCN_DISABLE_FROM_CHARS}>:      -DSCN_DISABLE_FROM_CHARS=1>
             $<$<BOOL:${SCN_DISABLE_STRTOD}>:          -DSCN_DISABLE_STRTOD=1>
+
+            $<$<BOOL:${SCN_DISABLE_LOCALE}>:          -DSCN_DISABLE_LOCALE=1>
             PARENT_SCOPE
     )
 endfunction()

--- a/include/scn/detail/config.h
+++ b/include/scn/detail/config.h
@@ -514,6 +514,11 @@
 #define SCN_DISABLE_STRTOD 0
 #endif
 
+// Define SCN_DISABLE_LOCALE
+#ifndef SCN_DISABLE_LOCALE
+#define SCN_DISABLE_LOCALE 0
+#endif
+
 #define SCN_UNUSED(x) static_cast<void>(sizeof(x))
 
 #if SCN_HAS_RELAXED_CONSTEXPR

--- a/include/scn/detail/locale.h
+++ b/include/scn/detail/locale.h
@@ -470,6 +470,15 @@ namespace scn {
 
         // default
         constexpr basic_locale_ref() = default;
+
+        // hardcoded "C", constexpr, should be preferred whenever possible
+        constexpr static_type get_static() const
+        {
+            return {};
+        }
+
+#if !SCN_USE_STATIC_LOCALE
+
         // nullptr = global
         constexpr basic_locale_ref(const void* p) : m_payload(p) {}
 
@@ -481,12 +490,6 @@ namespace scn {
         constexpr bool has_custom() const
         {
             return m_payload != nullptr;
-        }
-
-        // hardcoded "C", constexpr, should be preferred whenever possible
-        constexpr static_type get_static() const
-        {
-            return {};
         }
 
         // hardcoded "C", not constexpr
@@ -567,6 +570,7 @@ namespace scn {
         mutable detail::unique_ptr<custom_type> m_custom{nullptr};
         const void* m_payload{nullptr};
         default_type m_default{};
+#endif
     };
 
     template <typename CharT, typename Locale>

--- a/include/scn/detail/locale.h
+++ b/include/scn/detail/locale.h
@@ -477,7 +477,7 @@ namespace scn {
             return {};
         }
 
-#if !SCN_USE_STATIC_LOCALE
+#if !SCN_DISABLE_LOCALE
 
         // nullptr = global
         constexpr basic_locale_ref(const void* p) : m_payload(p) {}
@@ -570,7 +570,7 @@ namespace scn {
         mutable detail::unique_ptr<custom_type> m_custom{nullptr};
         const void* m_payload{nullptr};
         default_type m_default{};
-#endif
+#endif // !SCN_DISABLE_LOCALE
     };
 
     template <typename CharT, typename Locale>

--- a/include/scn/reader/common.h
+++ b/include/scn/reader/common.h
@@ -962,10 +962,12 @@ namespace scn {
                   m_width{width},
                   m_fn{get_fn(localized, width != 0)}
             {
+#if !SCN_USE_STATIC_LOCALE
                 if (localized) {
                     l.prepare_localized();
                     m_locale = l.get_localized_unsafe();
                 }
+#endif
             }
 
             /**
@@ -1056,9 +1058,11 @@ namespace scn {
 
             static SCN_CONSTEXPR14 fn_type get_fn(bool localized, bool counting)
             {
+#if !SCN_USE_STATIC_LOCALE
                 if (localized) {
                     return counting ? localized_call_counting : localized_call;
                 }
+#endif
                 return counting ? call_counting : call;
             }
         };

--- a/include/scn/reader/common.h
+++ b/include/scn/reader/common.h
@@ -962,7 +962,7 @@ namespace scn {
                   m_width{width},
                   m_fn{get_fn(localized, width != 0)}
             {
-#if !SCN_USE_STATIC_LOCALE
+#if !SCN_DISABLE_LOCALE
                 if (localized) {
                     l.prepare_localized();
                     m_locale = l.get_localized_unsafe();
@@ -1058,7 +1058,7 @@ namespace scn {
 
             static SCN_CONSTEXPR14 fn_type get_fn(bool localized, bool counting)
             {
-#if !SCN_USE_STATIC_LOCALE
+#if !SCN_DISABLE_LOCALE
                 if (localized) {
                     return counting ? localized_call_counting : localized_call;
                 }

--- a/include/scn/reader/float.h
+++ b/include/scn/reader/float.h
@@ -141,7 +141,7 @@ namespace scn {
                         has_negative_sign = true;
                         sign_offset = 1;
                     }
-#if SCN_USE_STATIC_LOCALE
+#if SCN_DISABLE_LOCALE
                     ret =
                         _read_float(tmp, s.subspan(sign_offset),
                                     ctx.locale().get_static().decimal_point());
@@ -172,7 +172,7 @@ namespace scn {
                                    tmp >= static_cast<T>(0.0));
                         tmp = -tmp;
                     }
-#endif
+#endif // SCN_DISABLE_LOCALE
 
                     if (!ret) {
                         return ret.error();

--- a/include/scn/reader/int.h
+++ b/include/scn/reader/int.h
@@ -231,6 +231,7 @@ namespace scn {
                 auto do_parse_int = [&](span<const char_type> s) -> error {
                     T tmp = 0;
                     expected<std::ptrdiff_t> ret{0};
+#if !SCN_USE_STATIC_LOCALE
                     if (SCN_UNLIKELY((format_options & localized_digits) !=
                                      0)) {
                         SCN_CLANG_PUSH_IGNORE_UNDEFINED_TEMPLATE
@@ -271,7 +272,9 @@ namespace scn {
                         }
                         SCN_CLANG_POP_IGNORE_UNDEFINED_TEMPLATE
                     }
-                    else {
+                    else
+#endif
+                    {
                         SCN_CLANG_PUSH_IGNORE_UNDEFINED_TEMPLATE
                         ret = _parse_int(tmp, s);
                         SCN_CLANG_POP_IGNORE_UNDEFINED_TEMPLATE
@@ -405,7 +408,11 @@ namespace scn {
                     return e;
                 }
                 auto thsep = ctx.locale()
+#if SCN_USE_STATIC_LOCALE
+                                 .get_static()
+#else
                                  .get((common_options & localized) != 0)
+#endif
                                  .thousands_separator();
 
                 auto it = tmp.begin();

--- a/include/scn/reader/int.h
+++ b/include/scn/reader/int.h
@@ -231,7 +231,7 @@ namespace scn {
                 auto do_parse_int = [&](span<const char_type> s) -> error {
                     T tmp = 0;
                     expected<std::ptrdiff_t> ret{0};
-#if !SCN_USE_STATIC_LOCALE
+#if !SCN_DISABLE_LOCALE
                     if (SCN_UNLIKELY((format_options & localized_digits) !=
                                      0)) {
                         SCN_CLANG_PUSH_IGNORE_UNDEFINED_TEMPLATE
@@ -273,7 +273,7 @@ namespace scn {
                         SCN_CLANG_POP_IGNORE_UNDEFINED_TEMPLATE
                     }
                     else
-#endif
+#endif // !SCN_DISABLE_LOCALE
                     {
                         SCN_CLANG_PUSH_IGNORE_UNDEFINED_TEMPLATE
                         ret = _parse_int(tmp, s);
@@ -408,7 +408,7 @@ namespace scn {
                     return e;
                 }
                 auto thsep = ctx.locale()
-#if SCN_USE_STATIC_LOCALE
+#if SCN_DISABLE_LOCALE
                                  .get_static()
 #else
                                  .get((common_options & localized) != 0)

--- a/include/scn/reader/string.h
+++ b/include/scn/reader/string.h
@@ -116,6 +116,7 @@ namespace scn {
 
                 if (get_option(flag::use_specifiers) &&
                     !get_option(flag::accept_all)) {
+#if !SCN_USE_STATIC_LOCALE
                     if (localized) {
                         if (get_option(specifier::letters)) {
                             get_option(specifier::letters) = false;
@@ -135,7 +136,9 @@ namespace scn {
                             get_option(specifier::digit) = true;
                         }
                     }
-                    else {
+                    else
+#endif
+                    {
                         auto do_range = [&](char a, char b) {
                             for (; a < b; ++a) {
                                 get_option(a) = true;
@@ -299,6 +302,7 @@ namespace scn {
                     return not_inverted;
                 }
 
+#if !SCN_USE_STATIC_LOCALE
                 if (get_option(flag::use_specifiers)) {
                     SCN_EXPECT(localized);  // ensured by sanitize()
                     SCN_UNUSED(localized);
@@ -353,6 +357,7 @@ namespace scn {
                     }
                     SCN_CLANG_POP_IGNORE_UNDEFINED_TEMPLATE
                 }
+#endif
                 if (get_option(flag::use_chars) && (ch >= 0 && ch <= 0x7f)) {
                     if (get_option(static_cast<char>(ch))) {
                         return not_inverted;

--- a/include/scn/reader/string.h
+++ b/include/scn/reader/string.h
@@ -116,7 +116,7 @@ namespace scn {
 
                 if (get_option(flag::use_specifiers) &&
                     !get_option(flag::accept_all)) {
-#if !SCN_USE_STATIC_LOCALE
+#if !SCN_DISABLE_LOCALE
                     if (localized) {
                         if (get_option(specifier::letters)) {
                             get_option(specifier::letters) = false;
@@ -137,7 +137,7 @@ namespace scn {
                         }
                     }
                     else
-#endif
+#endif // !SCN_DISABLE_LOCALE
                     {
                         auto do_range = [&](char a, char b) {
                             for (; a < b; ++a) {
@@ -302,7 +302,7 @@ namespace scn {
                     return not_inverted;
                 }
 
-#if !SCN_USE_STATIC_LOCALE
+#if !SCN_DISABLE_LOCALE
                 if (get_option(flag::use_specifiers)) {
                     SCN_EXPECT(localized);  // ensured by sanitize()
                     SCN_UNUSED(localized);
@@ -357,7 +357,7 @@ namespace scn {
                     }
                     SCN_CLANG_POP_IGNORE_UNDEFINED_TEMPLATE
                 }
-#endif
+#endif // !SCN_DISABLE_LOCALE
                 if (get_option(flag::use_chars) && (ch >= 0 && ch <= 0x7f)) {
                     if (get_option(static_cast<char>(ch))) {
                         return not_inverted;

--- a/include/scn/reader/types.h
+++ b/include/scn/reader/types.h
@@ -107,10 +107,12 @@ namespace scn {
                 if ((format_options & allow_string) != 0) {
                     auto truename = ctx.locale().get_static().truename();
                     auto falsename = ctx.locale().get_static().falsename();
+#if !SCN_USE_STATIC_LOCALE
                     if ((common_options & localized) != 0) {
                         truename = ctx.locale().get_localized().truename();
                         falsename = ctx.locale().get_localized().falsename();
                     }
+#endif
                     const auto max_len =
                         detail::max(truename.size(), falsename.size());
                     std::basic_string<char_type> buf;
@@ -155,6 +157,7 @@ namespace scn {
                 }
 
                 if ((format_options & allow_int) != 0) {
+#if !SCN_USE_STATIC_LOCALE
                     if ((format_options & localized_digits) != 0) {
                         int i{};
                         auto s = integer_scanner<int>{};
@@ -179,6 +182,7 @@ namespace scn {
                         }
                         return {};
                     }
+#endif
 
                     unsigned char buf[4] = {0};
                     auto cp = read_code_point(ctx.range(), make_span(buf, 4));

--- a/include/scn/reader/types.h
+++ b/include/scn/reader/types.h
@@ -107,7 +107,7 @@ namespace scn {
                 if ((format_options & allow_string) != 0) {
                     auto truename = ctx.locale().get_static().truename();
                     auto falsename = ctx.locale().get_static().falsename();
-#if !SCN_USE_STATIC_LOCALE
+#if !SCN_DISABLE_LOCALE
                     if ((common_options & localized) != 0) {
                         truename = ctx.locale().get_localized().truename();
                         falsename = ctx.locale().get_localized().falsename();
@@ -157,7 +157,7 @@ namespace scn {
                 }
 
                 if ((format_options & allow_int) != 0) {
-#if !SCN_USE_STATIC_LOCALE
+#if !SCN_DISABLE_LOCALE
                     if ((format_options & localized_digits) != 0) {
                         int i{};
                         auto s = integer_scanner<int>{};
@@ -182,7 +182,7 @@ namespace scn {
                         }
                         return {};
                     }
-#endif
+#endif // !SCN_DISABLE_LOCALE
 
                     unsigned char buf[4] = {0};
                     auto cp = read_code_point(ctx.range(), make_span(buf, 4));

--- a/src/reader_float.cpp
+++ b/src/reader_float.cpp
@@ -82,6 +82,7 @@ namespace scn {
                              size_t& chars,
                              uint8_t options)
             {
+#if !SCN_USE_STATIC_LOCALE
                 // Get current C locale
                 const auto loc = std::setlocale(LC_NUMERIC, nullptr);
                 // For whatever reason, this cannot be stored in the heap if
@@ -93,15 +94,19 @@ namespace scn {
                 std::strcpy(locbuf, loc);
 
                 std::setlocale(LC_NUMERIC, "C");
+#endif
 
                 CharT* end{};
                 errno = 0;
                 T f = f_strtod(str, &end);
                 chars = static_cast<size_t>(end - str);
                 auto err = errno;
+
+#if !SCN_USE_STATIC_LOCALE
                 // Reset locale
                 std::setlocale(LC_NUMERIC, locbuf);
                 errno = 0;
+#endif
 
                 SCN_GCC_COMPAT_PUSH
                 SCN_GCC_COMPAT_IGNORE("-Wfloat-equal")
@@ -299,9 +304,11 @@ namespace scn {
                     flags.format = static_cast<::fast_float::chars_format>(
                         flags.format | ::fast_float::scientific);
                 }
+#if !SCN_USE_STATIC_LOCALE
                 if ((options & detail::float_scanner<T>::localized) != 0) {
                     flags.decimal_point = locale_decimal_point;
                 }
+#endif
 
                 const auto result = ::fast_float::from_chars_advanced(
                     str, str + len, value, flags);

--- a/src/reader_float.cpp
+++ b/src/reader_float.cpp
@@ -82,7 +82,7 @@ namespace scn {
                              size_t& chars,
                              uint8_t options)
             {
-#if !SCN_USE_STATIC_LOCALE
+#if !SCN_DISABLE_LOCALE
                 // Get current C locale
                 const auto loc = std::setlocale(LC_NUMERIC, nullptr);
                 // For whatever reason, this cannot be stored in the heap if
@@ -102,7 +102,7 @@ namespace scn {
                 chars = static_cast<size_t>(end - str);
                 auto err = errno;
 
-#if !SCN_USE_STATIC_LOCALE
+#if !SCN_DISABLE_LOCALE
                 // Reset locale
                 std::setlocale(LC_NUMERIC, locbuf);
                 errno = 0;
@@ -304,7 +304,7 @@ namespace scn {
                     flags.format = static_cast<::fast_float::chars_format>(
                         flags.format | ::fast_float::scientific);
                 }
-#if !SCN_USE_STATIC_LOCALE
+#if !SCN_DISABLE_LOCALE
                 if ((options & detail::float_scanner<T>::localized) != 0) {
                     flags.decimal_point = locale_decimal_point;
                 }


### PR DESCRIPTION
This fixes the remaining issues in #69.
It was not as difficult as I imagined, but it took a much deeper understanding of the codebase.
Note that I dropped the locale override macros, as I later realized they were ill-conceived.

I have tried to be as minimally invasive as possible, mainly cutting out call-sites and letting the optimizer take care of the rest. This may not be the best solution, but it required the fewest changes. As far as I can tell, there are no remnants of `std::locale`.

My final size reduction is 135K!