### PR TITLE
Adds missing inline

### DIFF
--- a/include/scn/detail/range.h
+++ b/include/scn/detail/range.h
@@ -581,7 +581,7 @@ namespace scn {
         /**
          * Create a `range_wrapper` for any supported source range.
          */
-        static constexpr auto& wrap =
+        inline static constexpr auto& wrap =
             detail::static_const<detail::_wrap::fn>::value;
     }  // namespace
 


### PR DESCRIPTION
Adds missing inline so that the wrap symbol is not duplicated in every compilation unit