### PR TITLE
Add cast to int32_t

### DIFF
--- a/src/deps/fast_float/single_include/fast_float/fast_float.h
+++ b/src/deps/fast_float/single_include/fast_float/fast_float.h
@@ -2548,7 +2548,7 @@ namespace fast_float {
         if (-am.power2 >= mantissa_shift) {
             // have a denormal float
             int32_t shift = -am.power2 + 1;
-            cb(am, std::min(shift, 64));
+            cb(am, std::min<int32_t>(shift, 64));
             // check for round-up: if rounding-nearest carried us to the hidden bit.
             am.power2 = (am.mantissa < (uint64_t(1) << binary_format<T>::mantissa_explicit_bits())) ? 0 : 1;
             return;


### PR DESCRIPTION
I would like to port scnlib for esp target, but when I try to compile the library I got the following error: 
```
In file included from /home/hmartin/DEV/esp/components/esp-scnlib/scnlib/src/reader_float.cpp:49:
/home/hmartin/DEV/esp/components/esp-scnlib/scnlib/src/deps/fast_float/single_include/fast_float/fast_float.h: In function 'void fast_float::round(adjusted_mantissa&, callback)':
/home/hmartin/DEV/esp/components/esp-scnlib/scnlib/src/deps/fast_float/single_include/fast_float/fast_float.h:2551:28: error: no matching function for call to 'min(int32_t&, int)'
 2551 |             cb(am, std::min(shift, 64));
      |                    ~~~~~~~~^~~~~~~~~~~
In file included from /home/hmartin/.espressif/tools/xtensa-esp32-elf/esp-12.2.0_20230208/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/12.2.0/string:50,
                 from /home/hmartin/.espressif/tools/xtensa-esp32-elf/esp-12.2.0_20230208/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/12.2.0/bits/locale_classes.h:40,
                 from /home/hmartin/.espressif/tools/xtensa-esp32-elf/esp-12.2.0_20230208/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/12.2.0/bits/ios_base.h:41,
                 from /home/hmartin/.espressif/tools/xtensa-esp32-elf/esp-12.2.0_20230208/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/12.2.0/streambuf:41,
                 from /home/hmartin/.espressif/tools/xtensa-esp32-elf/esp-12.2.0_20230208/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/12.2.0/bits/streambuf_iterator.h:35,
                 from /home/hmartin/.espressif/tools/xtensa-esp32-elf/esp-12.2.0_20230208/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/12.2.0/iterator:66,
                 from /home/hmartin/DEV/esp/components/esp-scnlib/scnlib/include/scn/detail/../reader/../detail/../unicode/../util/memory.h:28,
                 from /home/hmartin/DEV/esp/components/esp-scnlib/scnlib/include/scn/detail/../reader/../detail/../unicode/../util/expected.h:21,
                 from /home/hmartin/DEV/esp/components/esp-scnlib/scnlib/include/scn/detail/../reader/../detail/../unicode/utf16.h:27,
                 from /home/hmartin/DEV/esp/components/esp-scnlib/scnlib/include/scn/detail/../reader/../detail/../unicode/unicode.h:26,
                 from /home/hmartin/DEV/esp/components/esp-scnlib/scnlib/include/scn/detail/../reader/../detail/locale.h:21,
                 from /home/hmartin/DEV/esp/components/esp-scnlib/scnlib/include/scn/detail/../reader/common.h:22,
                 from /home/hmartin/DEV/esp/components/esp-scnlib/scnlib/include/scn/detail/args.h:21,
                 from /home/hmartin/DEV/esp/components/esp-scnlib/scnlib/src/reader_float.cpp:22:
/home/hmartin/.espressif/tools/xtensa-esp32-elf/esp-12.2.0_20230208/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/12.2.0/bits/stl_algobase.h:230:5: note: candidate: 'template<class _Tp> constexpr const _Tp& std::min(const _Tp&, const _Tp&)'
  230 |     min(const _Tp& __a, const _Tp& __b)
      |     ^~~
/home/hmartin/.espressif/tools/xtensa-esp32-elf/esp-12.2.0_20230208/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/12.2.0/bits/stl_algobase.h:230:5: note:   template argument deduction/substitution failed:
/home/hmartin/DEV/esp/components/esp-scnlib/scnlib/src/deps/fast_float/single_include/fast_float/fast_float.h:2551:28: note:   deduced conflicting types for parameter 'const _Tp' ('long int' and 'int')
 2551 |             cb(am, std::min(shift, 64));
      |                    ~~~~~~~~^~~~~~~~~~~
/home/hmartin/.espressif/tools/xtensa-esp32-elf/esp-12.2.0_20230208/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/12.2.0/bits/stl_algobase.h:278:5: note: candidate: 'template<class _Tp, class _Compare> constexpr const _Tp& std::min(const _Tp&, const _Tp&, _Compare)'
  278 |     min(const _Tp& __a, const _Tp& __b, _Compare __comp)
      |     ^~~
/home/hmartin/.espressif/tools/xtensa-esp32-elf/esp-12.2.0_20230208/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/12.2.0/bits/stl_algobase.h:278:5: note:   template argument deduction/substitution failed:
/home/hmartin/DEV/esp/components/esp-scnlib/scnlib/src/deps/fast_float/single_include/fast_float/fast_float.h:2551:28: note:   deduced conflicting types for parameter 'const _Tp' ('long int' and 'int')
 2551 |             cb(am, std::min(shift, 64));
      |                    ~~~~~~~~^~~~~~~~~~~
In file included from /home/hmartin/.espressif/tools/xtensa-esp32-elf/esp-12.2.0_20230208/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/12.2.0/algorithm:61,
                 from /home/hmartin/DEV/esp/components/esp-scnlib/scnlib/src/deps/fast_float/single_include/fast_float/fast_float.h:1648:
/home/hmartin/.espressif/tools/xtensa-esp32-elf/esp-12.2.0_20230208/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/12.2.0/bits/stl_algo.h:5726:5: note: candidate: 'template<class _Tp> constexpr _Tp std::min(initializer_list<_Tp>)'
 5726 |     min(initializer_list<_Tp> __l)
      |     ^~~
/home/hmartin/.espressif/tools/xtensa-esp32-elf/esp-12.2.0_20230208/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/12.2.0/bits/stl_algo.h:5726:5: note:   template argument deduction/substitution failed:
/home/hmartin/DEV/esp/components/esp-scnlib/scnlib/src/deps/fast_float/single_include/fast_float/fast_float.h:2551:28: note:   mismatched types 'std::initializer_list<_Tp>' and 'long int'
 2551 |             cb(am, std::min(shift, 64));
      |                    ~~~~~~~~^~~~~~~~~~~
/home/hmartin/.espressif/tools/xtensa-esp32-elf/esp-12.2.0_20230208/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/12.2.0/bits/stl_algo.h:5736:5: note: candidate: 'template<class _Tp, class _Compare> constexpr _Tp std::min(initializer_list<_Tp>, _Compare)'
 5736 |     min(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
/home/hmartin/.espressif/tools/xtensa-esp32-elf/esp-12.2.0_20230208/xtensa-esp32-elf/xtensa-esp32-elf/include/c++/12.2.0/bits/stl_algo.h:5736:5: note:   template argument deduction/substitution failed:
/home/hmartin/DEV/esp/components/esp-scnlib/scnlib/src/deps/fast_float/single_include/fast_float/fast_float.h:2551:28: note:   mismatched types 'std::initializer_list<_Tp>' and 'long int'
 2551 |             cb(am, std::min(shift, 64));
      |                    ~~~~~~~~^~~~~~~~~~~
ninja: build stopped: subcommand failed.
```  

Expliciting the std::min function to use correct this problem. 
