### PR TITLE
fix android float_reader

### DIFF
--- a/src/scn/impl/reader/float_reader.cpp
+++ b/src/scn/impl/reader/float_reader.cpp
@@ -64,14 +64,14 @@ SCN_GCC_POP
 
 #if SCN_DISABLE_LOCALE
 #define SCN_XLOCALE SCN_XLOCALE_DISABLED
-#elif SCN_HAS_INCLUDE(<xlocale.h>)
+#elif (!defined(__ANDROID_API__)||__ANDROID_API__ >= 28 ) && SCN_HAS_INCLUDE(<xlocale.h>)
 #include <xlocale.h>
 #define SCN_XLOCALE SCN_XLOCALE_POSIX
 
 #elif defined(_MSC_VER)
 #define SCN_XLOCALE SCN_XLOCALE_MSVC
 
-#elif defined(__GLIBC__)
+#elif defined(__GLIBC__)&&!defined(__ANDROID_API__) 
 // glibc
 
 #include <features.h>


### PR DESCRIPTION
build on android 25c report error: 

```

/ mnt/vcpkg-ci/b/scnlib/src/v2.0.0-cc5e6bd45f.clean/src/scn/impl/reader/float_reader.cpp:272:22: error: no member named 'wcstof_l' in the global namespace; did you mean 'wcstold_l'?
            return ::wcstof_l(str, str_end, cloc);
                   ~~^~~~~~~~
                     wcstold_l
/android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/wchar.h:191:13: note: 'wcstold_l' declared here
long double wcstold_l(const wchar_t* __s, wchar_t** __end_ptr, locale_t __l) __INTRODUCED_IN(21);
            ^
/mnt/vcpkg-ci/b/scnlib/src/v2.0.0-cc5e6bd45f.clean/src/scn/impl/reader/float_reader.cpp:275:22: error: no member named 'wcstod_l' in the global namespace; did you mean 'wcstold_l'?
            return ::wcstod_l(str, str_end, cloc);
                   ~~^~~~~~~~
                     wcstold_l
/android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/wchar.h:191:13: note: 'wcstold_l' declared here
long double wcstold_l(const wchar_t* __s, wchar_t** __end_ptr, locale_t __l) __INTRODUCED_IN(21);


```
and from /android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/wchar.h we can see those  functions are only supported on __ANDROID_API__ >= 28

 131   │ #if __ANDROID_API__ >= 28
 132   │ double wcstod_l(const wchar_t* __s, wchar_t** __end_ptr, locale_t __l) __INTRODUCED_IN(28);
 133   │ #endif /* __ANDROID_API__ >= 28 */

 141   │ #if __ANDROID_API__ >= 28
 142   │ float wcstof_l(const wchar_t* __s, wchar_t** __end_ptr, locale_t __l) __INTRODUCED_IN(28);
 143   │ #endif /* __ANDROID_API__ >= 28 */
