### PR TITLE
Remove integer digit separator from preprocessor macro. Fix build with Clang

### DIFF
--- a/include/scn/detail/pp_detect.h
+++ b/include/scn/detail/pp_detect.h
@@ -51,7 +51,7 @@
 #endif
 
 #define SCN_COMPILER(major, minor, patch) \
-    ((major)*10'000'000 + (minor)*10'000 + (patch))
+    ((major)*10000000 /* 10,000,000 */ + (minor)*10000 /* 10,000 */ + (patch))
 
 #ifdef __INTEL_COMPILER
 // Intel


### PR DESCRIPTION
This pull request solves [this issue](https://github.com/eliaskosunen/scnlib/issues/110)

**This commit reverts the definition of SCN_COMPILER in pp_detect.h to what it was before commit https://github.com/eliaskosunen/scnlib/commit/1c3280ef4df45a40a2837eaf8f32593f727f906e**
Direct link to file change reverted: [include/scn/detail/pp_detect.h](https://github.com/eliaskosunen/scnlib/commit/1c3280ef4df45a40a2837eaf8f32593f727f906e#diff-3beafd2056ca9718810359b5e71f2d1a91285dd54b745e5e5b34814cdbdb8094)

The usage of the single-quote character as integer digit separator in preprocessor, results in build errors with Clang. (tested with clang versions 17,18 and 19). This probably happens because the preprocessor doesn't interpret the definition as an integer.
The error is generated by the dependency scanner.


### Another proposal:
Instead of reverting, another option to increase readability would be to use binary power, instead of base 10, for the version number, although the result would be different.
Example:
`( ((major) << 32) + ((minor) << 16) + (patch) )`
