### PR TITLE
Fix include CMAKE_INSTALL_INCLUDEDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
+include(GNUInstallDirs)
+
 include(cmake/util.cmake)
 include(cmake/options.cmake)
 include(cmake/buildflags.cmake)

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -2,7 +2,6 @@ if (NOT SCN_INSTALL)
     return()
 endif()
 
-include(GNUInstallDirs)
 set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/scn)
 
 set(targets "scn")


### PR DESCRIPTION
The `target_include_directories` changed from `$<INSTALL_INTERFACE:include>` to `$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>` in [8d6218a#diff](https://github.com/eliaskosunen/scnlib/commit/8d6218a0ed63e10da90399c65b93dd4eebf4bde3#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR127-R128), while `GNUInstallDirs` [cmake/install.cmake#L5](https://github.com/eliaskosunen/scnlib/blob/v2.0.2/cmake/install.cmake#L5) has not yet been included, led target `scn::scn` lost `INTERFACE_INCLUDE_DIRECTORIES`.

~Move the public include define `INSTALL_INTERFACE` to fix it.~
Move `include(GNUInstallDirs)` to fix it.