### PR TITLE
scan.h: fixed Manual indexing example

### DIFF
--- a/include/scn/scan.h
+++ b/include/scn/scan.h
@@ -7337,7 +7337,7 @@ constexpr void check_regex_type_specs(const format_specs& specs,
  *
  * // Manual indexing
  * auto b = scn::scan<int, int>("2 to 300", "{1} to {0}");
- * // b->values() == (3, 200)
+ * // b->values() == (300, 2)
  *
  * // INVALID:
  * // Automatic and manual indexing is mixed


### PR DESCRIPTION
Trivial stuff from reading the docs.