### PR TITLE
Add support for C++20 modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,19 @@ target_include_directories(scn_internal
 )
 set_interface_flags(scn_internal)
 
+option(SCNLIB_BUILD_MODULES "Build C++ modules support" OFF)
+
+if(SCNLIB_BUILD_MODULES)
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
+        message(STATUS "Building scnlib C++ modules (CMake ${CMAKE_VERSION} supports modules)")
+        add_subdirectory(src/modules)
+    else()
+        message(WARNING "Skipping scnlib C++ modules (requires CMake 3.28+, found ${CMAKE_VERSION})")
+    endif()
+else()
+    message(STATUS "scnlib C++ modules support is disabled. Enable with -DSCNLIB_BUILD_MODULES=ON")
+endif()
+
 add_subdirectory(scripts)
 
 add_subdirectory(benchmark)

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ int main() {
       string)
     * convenience (ranges)
     * ergonomics (values returned from `scn::scan`, no output parameters)
+    * support for modules (enable `SCNLIB_BUILD_MODULES` and `import scn;`)
 * `"{python}"`-like format string syntax
     * Including compile-time format string checking
 * Minimal code size increase (in user code, see Benchmarks)

--- a/include/scn/scan.h
+++ b/include/scn/scan.h
@@ -17,6 +17,14 @@
 
 #pragma once
 
+#ifdef SCNLIB_MODULES
+#define SCNLIB_MODULE_LINKAGE inline
+#define SCNLIB_MODULE_CONSTS_LINKAGE inline
+#else
+#define SCNLIB_MODULE_LINKAGE static
+#define SCNLIB_MODULE_CONSTS_LINKAGE 
+#endif
+
 // Includes <cassert>, <cstddef>, <cstdint>, and <type_traits>
 #include <scn/fwd.h>
 
@@ -425,7 +433,7 @@ void destroy_at(T* p) noexcept
 }
 
 struct deferred_init_tag_t {};
-static constexpr deferred_init_tag_t deferred_init_tag{};
+SCNLIB_MODULE_LINKAGE constexpr deferred_init_tag_t deferred_init_tag{};
 
 template <typename T,
           typename E,
@@ -5822,17 +5830,17 @@ using is_scannable = std::integral_constant<
         unscannable,
         remove_cvref_t<decltype(arg_mapper<CharT>().map(SCN_DECLVAL(T&)))>>>;
 
-constexpr std::size_t packed_arg_bits = 5;
+SCNLIB_MODULE_CONSTS_LINKAGE constexpr std::size_t packed_arg_bits = 5;
 static_assert((1 << packed_arg_bits) > static_cast<int>(arg_type::last_type),
               "If this fails, there are more `arg_type` values than values "
               "that can fit in `packed_arg_bits`. Either something needs to be "
               "removed from `arg_type` (spilling them to the stack), or "
               "`packed_arg_bits` must be increased (causing the number of "
               "arguments that can be packed to decrease)");
-constexpr std::size_t bits_in_sz = sizeof(std::size_t) * 8;
-constexpr std::size_t max_packed_args = (bits_in_sz - 2) / packed_arg_bits - 1;
-constexpr std::size_t is_unpacked_bit = std::size_t{1} << (bits_in_sz - 1);
-constexpr std::size_t has_custom_types_bit = std::size_t{1} << (bits_in_sz - 2);
+SCNLIB_MODULE_CONSTS_LINKAGE constexpr std::size_t bits_in_sz = sizeof(std::size_t) * 8;
+SCNLIB_MODULE_CONSTS_LINKAGE constexpr std::size_t max_packed_args = (bits_in_sz - 2) / packed_arg_bits - 1;
+SCNLIB_MODULE_CONSTS_LINKAGE constexpr std::size_t is_unpacked_bit = std::size_t{1} << (bits_in_sz - 1);
+SCNLIB_MODULE_CONSTS_LINKAGE constexpr std::size_t has_custom_types_bit = std::size_t{1} << (bits_in_sz - 2);
 
 template <typename>
 constexpr size_t encode_types_impl()

--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -1,0 +1,30 @@
+file(GLOB_RECURSE SCNLIB_MODULES *.cppm)
+
+add_library(scnlib_modules)
+
+cmake_minimum_required(VERSION 3.28)
+
+if(NOT COMMAND configure_cpp_module_target)
+  function(configure_cpp_module_target target)
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
+      target_sources(${target} PUBLIC FILE_SET CXX_MODULES FILES ${SCNLIB_MODULES})
+    else()
+      message(WARNING "C++ modules require CMake 3.28+. Using standard compilation.")
+      target_sources(${target} PRIVATE ${SCNLIB_MODULES})
+    endif()
+  endfunction()
+endif()
+
+configure_cpp_module_target(scnlib_modules)
+
+target_link_libraries(scnlib_modules
+  PUBLIC
+    scn::scn
+)
+
+target_include_directories(scnlib_modules
+  PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+)
+
+target_compile_features(scnlib_modules PUBLIC cxx_std_20)

--- a/src/modules/chrono.cppm
+++ b/src/modules/chrono.cppm
@@ -1,0 +1,58 @@
+// Copyright 2017 Elias Kosunen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This file is a part of scnlib:
+//     https://github.com/eliaskosunen/scnlib
+
+module;
+
+#define SCNLIB_MODULES
+#include <scn/chrono.h>
+
+export module scn.chrono;
+
+export namespace scn {
+    using scn::weekday;
+    using scn::day;
+    using scn::month;
+    using scn::year;
+
+    using scn::month_day;
+    using scn::year_month;
+    using scn::year_month_day;
+
+    using scn::Sunday;
+    using scn::Monday;
+    using scn::Tuesday;
+    using scn::Wednesday;
+    using scn::Thursday;
+    using scn::Friday;
+    using scn::Saturday;
+
+    using scn::January;
+    using scn::February;
+    using scn::March;
+    using scn::April;
+    using scn::May;
+    using scn::June;
+    using scn::July;
+    using scn::August;
+    using scn::September;
+    using scn::October;
+    using scn::November;
+    using scn::December;
+
+    using scn::datetime_components;
+    using scn::tm_with_tz;
+}

--- a/src/modules/istream.cppm
+++ b/src/modules/istream.cppm
@@ -1,0 +1,27 @@
+// Copyright 2017 Elias Kosunen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This file is a part of scnlib:
+//     https://github.com/eliaskosunen/scnlib
+
+module;
+
+#define SCNLIB_MODULES
+#include <scn/istream.h>
+
+export module scn.istream;
+
+export namespace scn {
+    using scn::basic_istream_scanner;
+}

--- a/src/modules/ranges.cppm
+++ b/src/modules/ranges.cppm
@@ -1,0 +1,29 @@
+// Copyright 2017 Elias Kosunen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This file is a part of scnlib:
+//     https://github.com/eliaskosunen/scnlib
+
+module;
+
+#define SCNLIB_MODULES
+#include <scn/ranges.h>
+
+export module scn.ranges;
+
+export namespace scn {
+    using scn::range_scanner;
+    using scn::range_format;
+    using scn::range_format_kind;
+}

--- a/src/modules/regex.cppm
+++ b/src/modules/regex.cppm
@@ -1,0 +1,28 @@
+// Copyright 2017 Elias Kosunen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This file is a part of scnlib:
+//     https://github.com/eliaskosunen/scnlib
+
+module;
+
+#define SCNLIB_MODULES
+#include <scn/regex.h>
+
+export module scn.regex;
+
+export namespace scn {
+    using scn::basic_regex_match;
+    using scn::basic_regex_matches;
+}

--- a/src/modules/scan.cppm
+++ b/src/modules/scan.cppm
@@ -1,0 +1,138 @@
+// Copyright 2017 Elias Kosunen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This file is a part of scnlib:
+//     https://github.com/eliaskosunen/scnlib
+
+module;
+
+#define SCNLIB_MODULES
+#include <scn/scan.h>
+#include <scn/xchar.h>
+
+export module scn.scan;
+
+export namespace scn {
+    using scn::unexpected;
+    using scn::expected;
+
+    namespace ranges {
+        using scn::ranges::enable_borrowed_range;
+        using scn::ranges::equality_comparable;
+        using scn::ranges::equality_comparable_with;
+        using scn::ranges::totally_ordered;
+        using scn::ranges::totally_ordered_with;
+        using scn::ranges::movable;
+        using scn::ranges::copyable;
+        using scn::ranges::semiregular;
+        using scn::ranges::regular;
+        using scn::ranges::incrementable_traits;
+        using scn::ranges::iter_difference_t;
+        using scn::ranges::readable_traits;
+        using scn::ranges::iter_value_t;
+        using scn::ranges::bidirectional_iterator_tag;
+        using scn::ranges::forward_iterator_tag;
+        using scn::ranges::input_iterator_tag;
+        using scn::ranges::output_iterator_tag;
+        using scn::ranges::random_access_iterator_tag;
+        using scn::ranges::contiguous_iterator_tag;
+        using scn::ranges::iterator_category;
+        using scn::ranges::iterator_category_t;
+        using scn::ranges::iter_reference_t;
+        using scn::ranges::writable;
+        using scn::ranges::weakly_incrementable;
+        using scn::ranges::incrementable;
+        using scn::ranges::input_or_output_iterator;
+        using scn::ranges::sentinel_for;
+        using scn::ranges::disable_sized_sentinel;
+        using scn::ranges::sized_sentinel_for;
+        using scn::ranges::input_iterator;
+        using scn::ranges::output_iterator;
+        using scn::ranges::forward_iterator;
+        using scn::ranges::bidirectional_iterator;
+        using scn::ranges::random_access_iterator;
+        using scn::ranges::contiguous_iterator;
+        using scn::ranges::begin;
+        using scn::ranges::end;
+        using scn::ranges::range;
+        using scn::ranges::iterator_t;
+        using scn::ranges::sentinel_t;
+        using scn::ranges::range_difference_t;
+        using scn::ranges::range_value_t;
+        using scn::ranges::range_reference_t;
+        using scn::ranges::data;
+        using scn::ranges::disable_sized_range;
+        using scn::ranges::size;
+        using scn::ranges::ssize;
+        using scn::ranges::empty;
+        using scn::ranges::borrowed_range;
+        using scn::ranges::sized_range;
+        using scn::ranges::output_range;
+        using scn::ranges::input_range;
+        using scn::ranges::forward_range;
+        using scn::ranges::bidirectional_range;
+        using scn::ranges::random_access_range;
+        using scn::ranges::contiguous_range;
+        using scn::ranges::dangling;
+        using scn::ranges::borrowed_iterator_t;
+        using scn::ranges::view_interface;
+        using scn::ranges::subrange;
+        using scn::ranges::enable_borrowed_range;
+        using scn::ranges::default_sentinel_t;
+        using scn::ranges::enable_borrowed_range;
+    }
+
+    using scn::scan_error;
+    using scn::operator==;
+    using scn::operator!=;
+    using scn::scan_format_string_error;
+    using scn::scan_expected;
+
+    using scn::invalid_input_range;
+    using scn::invalid_char_type;
+    using scn::file_marker_found;
+    using scn::insufficient_range;
+
+    using scn::basic_scan_arg;
+    using scn::make_scan_args;
+    using scn::make_wscan_args;
+    using scn::basic_scan_args;
+    
+    using scn::basic_scan_parse_context;
+    
+    using scn::scan_result;
+
+    using scn::runtime_format;
+    using scn::basic_scan_format_string;
+
+    using scn::basic_scan_context;
+
+    using scn::scanner;
+    using scn::discard;
+    using scn::visit_scan_arg; // Deprecated
+    
+    using scn::vscan_result;
+    using scn::vscan;
+    using scn::vscan_value;
+
+    using scn::scan_result_type;
+    using scn::fill_scan_result;
+    using scn::make_scan_result;
+    using scn::scan;
+    using scn::scan_value;
+    using scn::input;
+    using scn::prompt;
+    using scn::scan_int;
+    using scn::scan_int_exhaustive_valid;
+}

--- a/src/modules/scn.cppm
+++ b/src/modules/scn.cppm
@@ -1,0 +1,24 @@
+// Copyright 2017 Elias Kosunen
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This file is a part of scnlib:
+//     https://github.com/eliaskosunen/scnlib
+
+export module scn;
+
+export import scn.chrono;
+export import scn.istream;
+export import scn.ranges;
+export import scn.regex;
+export import scn.scan;


### PR DESCRIPTION
This pull request adds support for C++20 modules, adding the modules `scn` and `scn.*`. Building modules must be enabled with `SCNLIB_BUILD_MODULES` in CMake.