### PR TITLE
Fix scanning ranges with libc++ bounded iterators

### DIFF
--- a/include/scn/scan.h
+++ b/include/scn/scan.h
@@ -268,6 +268,16 @@ struct wrapped_pointer_iterator<std::__wrap_iter<Elem*>> {
         return it.base();
     }
 };
+#ifdef _LIBCPP_ABI_BOUNDED_ITERATORS
+template <typename Elem>
+struct wrapped_pointer_iterator<std::__bounded_iter<Elem*>> {
+    SCN_FORCE_INLINE static constexpr auto to_address(
+        const std::__bounded_iter<Elem*>& it) noexcept
+    {
+        return std::pointer_traits<std::__bounded_iter<Elem*>>::to_address(it);
+    }
+};
+#endif
 #endif
 
 template <typename I>


### PR DESCRIPTION
Currently, `scn::detail::to_address()` doesn't have a template for bounded iterators from libc++, which can be enabled in custom builds with `-DLIBCXX_ABI_DEFINES="_LIBCPP_ABI_BOUNDED_ITERATORS` (there are several kinds of them). This causes spurious crashes when scanning `std::string_view` and other ranges that support hardened iterators.

Add a template for bounded iterators if the target stdlib is libc++ and `_LIBCPP_ABI_BOUNDED_ITERATORS` is defined. There's no `::base()` method in them, so just use `std::pointer_traits<>` directly (it doesn't require C++20 or newer, unlike `std::to_address()`).